### PR TITLE
Added a release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,58 @@
+name: goreleaser
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+  actions: read
+
+jobs:
+  test:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    outputs:
+      status: ${{ job.status }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+          cache: true
+
+      - name: Install dependencies
+        run: go mod download
+
+      - name: Run tests
+        run: go test -v ./...
+
+      - name: Run build
+        run: go build -v ./...
+
+  goreleaser:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}

--- a/.github/workflows/test-and-tag.yml
+++ b/.github/workflows/test-and-tag.yml
@@ -1,0 +1,40 @@
+name: Test and Tag
+
+on:
+  pull_request:
+  push:
+    paths-ignore:
+      - "README.md"
+      - "doc/**"
+      - ".github/workflows/release.yml"
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  test:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    outputs:
+      status: ${{ job.status }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+          cache: true
+
+      - name: Install dependencies
+        run: go mod download
+
+      - name: Run tests
+        run: go test -v ./...
+
+      - name: Run build
+        run: go build -v ./...

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -28,10 +28,10 @@ brews:
     url_template: "https://github.com/emicklei/mcp-log-proxy/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
     commit_author:
       name: Ernest Micklei
-      email: gh@flaticols.dev
+      email: ernest.micklei@gmail.com
     directory: Formula
-    homepage: "https://bump.flaticols.dev"
-    description: "Bump semver git tag in yours repository"
+    homepage: "https://github.com/emicklei/mcp-log-proxy"
+    description: "a web logging proxy for MCP client-server communication"
     commit_msg_template: "Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
     license: "MIT"
     repository:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -36,7 +36,7 @@ brews:
     license: "MIT"
     repository:
       owner: emicklei
-      name: homebrew-taps
+      name: homebrew-tap
       branch: main
 
 changelog:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,47 @@
+version: 2
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+
+archives:
+  - formats: [tar.gz]
+    # this name template makes the OS and Arch compatible with the results of `uname`.
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    # use zip for windows archives
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+
+brews:
+  - name: mcp-log-proxy
+    url_template: "https://github.com/emicklei/mcp-log-proxy/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+    commit_author:
+      name: Ernest Micklei
+      email: gh@flaticols.dev
+    directory: Formula
+    homepage: "https://bump.flaticols.dev"
+    description: "Bump semver git tag in yours repository"
+    commit_msg_template: "Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
+    license: "MIT"
+    repository:
+      owner: emicklei
+      name: homebrew-taps
+      branch: main
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"

--- a/instance-selector.go
+++ b/instance-selector.go
@@ -1,0 +1,4 @@
+package main
+
+type instanceSelector struct {
+}


### PR DESCRIPTION
This PR adds GoReleaser configuration and a GitHub Workflow to build and publish releases to GitHub Releases and Ernest's homebrew-tap.

The release pipeline is triggered by pushing a semver tag, for example, `v1.0.3`.

Users can install map-log-proxy:

```
brew install emicklei/mcp-log-proxy
```